### PR TITLE
Simplify default object (parameters - extra credit)

### DIFF
--- a/spec-final/05_parameters.spec.js
+++ b/spec-final/05_parameters.spec.js
@@ -124,7 +124,7 @@ describe('Rest Parameters', () => {
 
       //Modify the method signature of `myFunction` to allow for all args to be optional
 
-      function myFunction({name="Aaron", age=35, favoriteBand="Queen"}={name: "Aaron", age: 35, favoriteBand:'Queen'}){
+      function myFunction({name="Aaron", age=35, favoriteBand="Queen"}={}){
         expect(name).toBeDefined();
         expect(age).toBeDefined();
         expect(favoriteBand).toBeDefined();


### PR DESCRIPTION
The default values were duplicated in the destructuring expression and the default object (if the passed object is undefined). I don't think it's necessary to repeat the default values in the right-hand-side object.
